### PR TITLE
그룹가입화면을 리팩토링했어요.

### DIFF
--- a/dogether/Data/RepositoryTest/GroupRepositoryTest.swift
+++ b/dogether/Data/RepositoryTest/GroupRepositoryTest.swift
@@ -18,6 +18,10 @@ final class GroupRepositoryTest: GroupProtocol {
     }
     
     func joinGroup(joinGroupRequest: JoinGroupRequest) async throws -> JoinGroupResponse {
+        // 999999 입력 시 에러
+        if joinGroupRequest.joinCode == "999999" {
+            throw URLError(.badServerResponse)
+        }
         return JoinGroupResponse(name: "testGroup", maximumMemberCount: 10, startAt: "2025-01-01", endAt: "2025-01-04", durationOption: 3)
     }
     

--- a/dogether/Data/RepositoryTest/GroupRepositoryTest.swift
+++ b/dogether/Data/RepositoryTest/GroupRepositoryTest.swift
@@ -18,10 +18,8 @@ final class GroupRepositoryTest: GroupProtocol {
     }
     
     func joinGroup(joinGroupRequest: JoinGroupRequest) async throws -> JoinGroupResponse {
-        // test: 99999999 입력 시 에러
-        if joinGroupRequest.joinCode == "99999999" {
-            throw URLError(.badServerResponse)
-        }
+        // MARK: - TEST: 99999999 입력 시 에러 발생 테스트
+        if joinGroupRequest.joinCode == "99999999" { throw NetworkError.unknown }
         return JoinGroupResponse(name: "testGroup", maximumMemberCount: 10, startAt: "2025-01-01", endAt: "2025-01-04", durationOption: 3)
     }
     

--- a/dogether/Data/RepositoryTest/GroupRepositoryTest.swift
+++ b/dogether/Data/RepositoryTest/GroupRepositoryTest.swift
@@ -18,8 +18,8 @@ final class GroupRepositoryTest: GroupProtocol {
     }
     
     func joinGroup(joinGroupRequest: JoinGroupRequest) async throws -> JoinGroupResponse {
-        // 999999 입력 시 에러
-        if joinGroupRequest.joinCode == "999999" {
+        // test: 99999999 입력 시 에러
+        if joinGroupRequest.joinCode == "99999999" {
             throw URLError(.badServerResponse)
         }
         return JoinGroupResponse(name: "testGroup", maximumMemberCount: 10, startAt: "2025-01-01", endAt: "2025-01-04", durationOption: 3)

--- a/dogether/Domain/Entity/Enum/GroupJoinStatus.swift
+++ b/dogether/Domain/Entity/Enum/GroupJoinStatus.swift
@@ -37,4 +37,13 @@ enum GroupJoinStatus {
             return Fonts.body1S
         }
     }
+    
+    var borderColor: UIColor {
+        switch self {
+        case .normal:
+            return .clear
+        case .error:
+            return .dogetherRed
+        }
+    }
 }

--- a/dogether/Domain/Entity/Enum/GroupJoinStatus.swift
+++ b/dogether/Domain/Entity/Enum/GroupJoinStatus.swift
@@ -16,7 +16,7 @@ enum GroupJoinStatus {
         case .normal:
             return "초대받은 링크에서 초대코드를 확인할 수 있어요"
         case .error:
-            return "해당 번호는 존재하지 않아요!"
+            return "해당 번호는 존재하지 않아요 !"
         }
     }
     

--- a/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
+++ b/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
@@ -26,7 +26,7 @@ final class GroupJoinViewController: BaseViewController {
     private let codeTextField = {
         let textField = UITextField()
         textField.attributedPlaceholder = NSAttributedString(
-            string: "코드입력 (6자리 이상)",
+            string: "코드입력 (8자리)",
             attributes: [
                 .foregroundColor: UIColor.grey300
             ]
@@ -158,8 +158,7 @@ extension GroupJoinViewController {
     }
     
     private func updateCodetextField() {
-        codeTextField.layer.borderColor = viewModel.status.textColor.cgColor
-        codeTextField.text = ""
+        codeTextField.layer.borderColor = viewModel.status.borderColor.cgColor
     }
 }
 

--- a/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
+++ b/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
@@ -191,8 +191,10 @@ extension GroupJoinViewController {
     private func updateUIForKeyboard() {
         UIView.animate(withDuration: 0.35) { [weak self] in
             guard let self = self else { return }
+            let safeAreaBottom = view.safeAreaInsets.bottom
+            let adjustedKeyboardHeight = max(keyboardHeight - safeAreaBottom, 0)
             if keyboardHeight > 0 {
-                joinButtonBottomConstraint?.update(inset: keyboardHeight + buttonBottomInset)
+                joinButtonBottomConstraint?.update(inset: adjustedKeyboardHeight + buttonBottomInset)
             } else {
                 joinButtonBottomConstraint?.update(inset: buttonBottomInset)
             }

--- a/dogether/Presentation/Features/GroupJoin/GroupJoinViewModel.swift
+++ b/dogether/Presentation/Features/GroupJoin/GroupJoinViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 final class GroupJoinViewModel {
     private let groupUseCase: GroupUseCase
     
-    let codeLength = 6
+    let codeLength = 8
     
     private(set) var code: String = ""
     private(set) var status: GroupJoinStatus = .normal


### PR DESCRIPTION
### 📝 Issue Number
- #11 

### 🔧 변경 사항
- 코드 입력 텍스트필드 UI를 변경했어요.
- 키보드가 올라올 때 '가입하기' 버튼이 함께 올라오도록 개선했어요.
- 잘못된 초대코드 입력 시 텍스트필드 보더 색을 변경하도록 개선했어요.
- 초대코드 자릿수를 6자리에서 8자리로 변경했어요.
- `codeTextField.becomeFirstResponder()`의 호출 시점을 viewDidAppear()로 변경했어요.

### 🔗 참고 자료
<img src="https://github.com/user-attachments/assets/50e2960e-d7eb-4154-8140-1f87f1c6ccf4" width="200"/> <img src="https://github.com/user-attachments/assets/3218efab-ae69-4ff9-9cbb-53d9efc0464c" width="200"/> 

<img src="https://github.com/user-attachments/assets/13c0f4c7-7edb-4734-963f-271d59c77122" width="200"/>
<img src="https://github.com/user-attachments/assets/0b9d13a1-074f-4675-ba52-a5054f20855b" width="200"/>



### 🧐 추가 설명
- `textFieldDidBeginEditing`와 `textFieldDidEndEditing`는
`UITextField`의 **편집 상태가 시작되거나 끝날 때 호출**되는 델리게이트 메서드입니다.
이 메서드들은 키보드가 나타날 때, 사라질 때와 관련이 있지만
**키보드의 높이에 대한 정보를 제공하지는 않습니다.**
이 메서드들 안에서 가입 버튼을 키보드 위로 올리려면
키보드 높이를 예측해서 하드코딩으로 처리해야 하는데,
**기기마다 키보드 높이가 다르기 때문에 UI가 깨질 가능성이 있습니다.**
즉, **키보드의 실제 높이를 정확히 알고 UI를 조정하려면,**
`keyboardWillShowNotification`을 통해
`userInfo` 안에 있는 **키보드의 frame 값을 사용하는 것이 가장 안전하고 확실한 방법입니다.**
`addObserver`나 `@objc` 메서드 사용을 최소화하고
Swift다운 방식으로 구현하고자,
**NotificationCenter를 Combine의 Publisher로 변환해 키보드 이벤트를 감지했습니다.**
이를 통해 **키보드가 나타나거나 사라질 때의 상태 변화를 감지하여 높이 값을 받아,**
가입 버튼의 위치를 자연스럽게 조정할 수 있도록 구현했습니다
