### PR TITLE
NavigationHeader UI와 네이밍을 수정했어요

### DIFF
--- a/dogether/Presentation/Common/NavigationHeader.swift
+++ b/dogether/Presentation/Common/NavigationHeader.swift
@@ -51,9 +51,13 @@ final class NavigationHeader: BaseView{
     }
      
     override func configureConstraints() {
+        self.snp.makeConstraints {
+            $0.height.equalTo(56)
+        }
+        
         prevButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.left.equalToSuperview()
+            $0.left.equalToSuperview().offset(16)
             $0.width.height.equalTo(24)
         }
         

--- a/dogether/Presentation/Features/GroupCreate/GroupCreateViewController.swift
+++ b/dogether/Presentation/Features/GroupCreate/GroupCreateViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 final class GroupCreateViewController: BaseViewController {
     private let viewModel = GroupCreateViewModel()
     
-    private let dogetherHeader = NavigationHeader(title: "그룹 만들기")
+    private let navigationHeader = NavigationHeader(title: "그룹 만들기")
     
     private let currentStepLabel = {
         let label = UILabel()
@@ -182,7 +182,7 @@ final class GroupCreateViewController: BaseViewController {
     override func configureAction() {
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard)))
         
-        dogetherHeader.delegate = self
+        navigationHeader.delegate = self
         
         completeButton.addAction(
             UIAction { [weak self] _ in
@@ -237,7 +237,7 @@ final class GroupCreateViewController: BaseViewController {
     }
     
     override func configureHierarchy() {
-        [ dogetherHeader, stepLabelStackView, stepDescriptionLabel, completeButton,
+        [ navigationHeader, stepLabelStackView, stepDescriptionLabel, completeButton,
           stepOneView, stepTwoView, stepThreeView
         ].forEach { view.addSubview($0) }
         
@@ -249,14 +249,13 @@ final class GroupCreateViewController: BaseViewController {
     }
     
     override func configureConstraints() {
-        dogetherHeader.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(28)
+        navigationHeader.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
         }
         
         stepLabelStackView.snp.makeConstraints {
-            $0.top.equalTo(dogetherHeader.snp.bottom).offset(56)
+            $0.top.equalTo(navigationHeader.snp.bottom).offset(42)
             $0.left.equalToSuperview().inset(16)
             $0.height.equalTo(25)
         }

--- a/dogether/Presentation/Features/GroupCreate/GroupCreateViewController.swift
+++ b/dogether/Presentation/Features/GroupCreate/GroupCreateViewController.swift
@@ -255,7 +255,7 @@ final class GroupCreateViewController: BaseViewController {
         }
         
         stepLabelStackView.snp.makeConstraints {
-            $0.top.equalTo(navigationHeader.snp.bottom).offset(42)
+            $0.top.equalTo(navigationHeader.snp.bottom).offset(44)
             $0.left.equalToSuperview().inset(16)
             $0.height.equalTo(25)
         }

--- a/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
+++ b/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class GroupJoinViewController: BaseViewController {
     private let viewModel = GroupJoinViewModel()
     
-    private let dogetherHeader = NavigationHeader(title: "그룹 가입하기")
+    private let navigationHeader = NavigationHeader(title: "그룹 가입하기")
     
     private let titleLabel = {
         let label = UILabel()
@@ -73,7 +73,7 @@ final class GroupJoinViewController: BaseViewController {
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard)))
         codeLabelStackView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(showKeyboard)))
         
-        dogetherHeader.delegate = self
+        navigationHeader.delegate = self
         
         textField.delegate = self
         textField.addAction(
@@ -110,19 +110,18 @@ final class GroupJoinViewController: BaseViewController {
     }
     
     override func configureHierarchy() {
-        [dogetherHeader, titleLabel, subTitleLabel, textField, codeLabelStackView, joinButton].forEach { view.addSubview($0) }
+        [navigationHeader, titleLabel, subTitleLabel, textField, codeLabelStackView, joinButton].forEach { view.addSubview($0) }
     }
     
     override func configureConstraints() {
-        dogetherHeader.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(28)
+        navigationHeader.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
         }
 
         titleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(100)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(48)
             $0.height.equalTo(36)
         }
         

--- a/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
+++ b/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
@@ -121,7 +121,7 @@ final class GroupJoinViewController: BaseViewController {
 
         titleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(48)
+            $0.top.equalTo(navigationHeader.snp.bottom).offset(48)
             $0.height.equalTo(36)
         }
         

--- a/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
+++ b/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
@@ -121,7 +121,7 @@ final class GroupJoinViewController: BaseViewController {
 
         titleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(navigationHeader.snp.bottom).offset(48)
+            $0.top.equalTo(navigationHeader.snp.bottom).offset(44)
             $0.height.equalTo(36)
         }
         

--- a/dogether/Presentation/Features/MyPage/MyPageViewController.swift
+++ b/dogether/Presentation/Features/MyPage/MyPageViewController.swift
@@ -96,7 +96,7 @@ final class MyPageViewController: BaseViewController {
         }
 
         profileImageView.snp.makeConstraints {
-            $0.top.equalTo(navigationHeader.snp.bottom)
+            $0.top.equalTo(navigationHeader.snp.bottom).offset(6)
             $0.centerX.equalToSuperview()
             $0.width.height.equalTo(100)
         }

--- a/dogether/Presentation/Features/MyPage/MyPageViewController.swift
+++ b/dogether/Presentation/Features/MyPage/MyPageViewController.swift
@@ -11,7 +11,7 @@ import SnapKit
 final class MyPageViewController: BaseViewController {
     private let viewModel = MyPageViewModel()
     
-    private let dogetherHeader = NavigationHeader(title: "마이페이지")
+    private let navigationHeader = NavigationHeader(title: "마이페이지")
     
     // FIXME: API 수정 후 내용 반영
     private let profileImageView = UIImageView(image: .profile2)
@@ -43,7 +43,7 @@ final class MyPageViewController: BaseViewController {
     }
     
     override func configureAction() {
-        dogetherHeader.delegate = self
+        navigationHeader.delegate = self
         
         leaveGroupButton.addAction(
             UIAction { [weak self] _ in
@@ -86,18 +86,17 @@ final class MyPageViewController: BaseViewController {
     }
     
     override func configureHierarchy() {
-        [dogetherHeader, profileImageView, nameLabel, mypageButtonStackView].forEach { view.addSubview($0) }
+        [navigationHeader, profileImageView, nameLabel, mypageButtonStackView].forEach { view.addSubview($0) }
     }
     
     override func configureConstraints() {
-        dogetherHeader.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(28)
+        navigationHeader.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
         }
 
         profileImageView.snp.makeConstraints {
-            $0.top.equalTo(dogetherHeader.snp.bottom).offset(56)
+            $0.top.equalTo(navigationHeader.snp.bottom)
             $0.centerX.equalToSuperview()
             $0.width.height.equalTo(100)
         }

--- a/dogether/Presentation/Features/Ranking/RankingViewController.swift
+++ b/dogether/Presentation/Features/Ranking/RankingViewController.swift
@@ -84,13 +84,12 @@ final class RankingViewController: BaseViewController {
     
     override func configureConstraints() {
         navigationHeader.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(28)
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
         }
         
         rankingTopStackView.snp.makeConstraints {
-            $0.top.equalTo(navigationHeader.snp.bottom).offset(16)
+            $0.top.equalTo(navigationHeader.snp.bottom).offset(8)
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(190)
         }

--- a/dogether/Presentation/Features/TodoWrite/TodoWriteViewController.swift
+++ b/dogether/Presentation/Features/TodoWrite/TodoWriteViewController.swift
@@ -210,7 +210,7 @@ final class TodoWriteViewController: BaseViewController {
         }
         
         dateLabel.snp.makeConstraints {
-            $0.top.equalTo(navigationHeader.snp.bottom).offset(10)
+            $0.top.equalTo(navigationHeader.snp.bottom).offset(12)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         

--- a/dogether/Presentation/Features/TodoWrite/TodoWriteViewController.swift
+++ b/dogether/Presentation/Features/TodoWrite/TodoWriteViewController.swift
@@ -205,13 +205,12 @@ final class TodoWriteViewController: BaseViewController {
     
     override func configureConstraints() {
         navigationHeader.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(28)
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
         }
         
         dateLabel.snp.makeConstraints {
-            $0.top.equalTo(navigationHeader.snp.bottom).offset(22)
+            $0.top.equalTo(navigationHeader.snp.bottom).offset(10)
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
         


### PR DESCRIPTION
### 📝 Issue Number
- #15 

### 🔧 변경 사항
- NavigationHeader UI와 네이밍을 수정했어요

###  🔍 변경 이유
- Figma에서 navigationHeader를 너무 다 다르게 사용해요... ~~(디자이너님들한테 말씀을 한 번 드리긴 해야할 것 같아요)~~ 변경된 navigationHeader에 맞게 height를 수정하고 해당 height에 맞게 화면별 수치를 조정했어요
- UI변경을 적용하며 네이밍을 통일했어요

### 🔗 참고 자료
- [Figma(기존 navigationHeader)](https://www.figma.com/design/hy4zveKj4xCoMSeUcjJd7x/-%EC%B0%90-DND12%EA%B8%B0_1%EC%A1%B0?node-id=2834-8725&t=ND99FJVl1s1slcDR-11)
- [Figma(변경된 navigationHeader)](https://www.figma.com/design/hy4zveKj4xCoMSeUcjJd7x/-%EC%B0%90-DND12%EA%B8%B0_1%EC%A1%B0?node-id=3239-9341&t=ND99FJVl1s1slcDR-11)

### 🧐 추가 설명
- UI자체가 바뀌면서 기존 UI에서 수치를 조정하는 게 의미가 없는 화면이 몇 포함되어있어요 (투두 작성 화면, 그룹 가입 화면 등) 해당 화면을 작업할 때 $0.top.equalTo(navigationHeader.snp.bottom).offset()에 해당하는 수치를 확인해주세요
- 디자이너님들한테 말씀을 드려버렸습니다 피그마에 헤더 UI가 아마 통일 될 것 같아요 이제 통일되게 작업할 수 있을 것 같습니다!
