### PR TITLE
그룹관리 페이지 API 연결 문제를 해결해요.

### DIFF
--- a/dogether/Data/Network/Response/GetMyGroupResponse.swift
+++ b/dogether/Data/Network/Response/GetMyGroupResponse.swift
@@ -8,12 +8,6 @@
 import Foundation
 
 struct GetMyGroupResponse: Decodable {
-    let code: String
-    let message: String
-    let data: GroupData
-}
-
-struct GroupData: Decodable {
     let joiningChallengeGroups: [ChallengeGroup]
 }
 

--- a/dogether/Data/Network/Router/GroupsRouter.swift
+++ b/dogether/Data/Network/Router/GroupsRouter.swift
@@ -13,7 +13,7 @@ enum GroupsRouter: NetworkEndpoint {
     case getGroups
     case getMySummary
     case getRanking(groupId: String)
-    case leaveGroup
+    case leaveGroup(groupId: Int)
     case getMyGroups
     
     var path: String {
@@ -28,8 +28,8 @@ enum GroupsRouter: NetworkEndpoint {
             return Path.api + Path.groups + Path.summary + "/my"
         case .getRanking(let groupId):
             return Path.api + Path.groups + "/\(groupId)/ranking"
-        case .leaveGroup:
-            return Path.api + Path.groups + "/leave"
+        case .leaveGroup(let groupId):
+            return Path.api + Path.groups + "/\(groupId)/leave"
         case .getMyGroups:
             return Path.api + Path.groups + "/my"
         }

--- a/dogether/Presentation/Features/GroupManagement/GroupManagementViewController.swift
+++ b/dogether/Presentation/Features/GroupManagement/GroupManagementViewController.swift
@@ -22,7 +22,6 @@ final class GroupManagementViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
-
     
     override func configureView() {
         groupTableView.delegate = self
@@ -70,7 +69,7 @@ extension GroupManagementViewController: UITableViewDataSource, UITableViewDeleg
             guard let self else { return }
             coordinator?.showPopup(self, type: .alert, alertType: .leaveGroup) { _ in
                 Task {
-                    try await self.viewModel.leaveGroup()
+                    try await self.viewModel.leaveGroup(groupId: group.groupId)
                     await MainActor.run {
                         self.coordinator?.setNavigationController(StartViewController())
                     }

--- a/dogether/Presentation/Features/GroupManagement/GroupManagementViewController.swift
+++ b/dogether/Presentation/Features/GroupManagement/GroupManagementViewController.swift
@@ -71,7 +71,15 @@ extension GroupManagementViewController: UITableViewDataSource, UITableViewDeleg
                 Task {
                     try await self.viewModel.leaveGroup(groupId: group.groupId)
                     await MainActor.run {
-                        self.coordinator?.setNavigationController(StartViewController())
+                        self.viewModel.fetchMyGroup { [weak self] in
+                            guard let self else { return }
+                            self.groupTableView.reloadData()
+                            
+                            // 그룹이 비어 있으면 StartViewController로 이동
+                            if self.viewModel.groups.isEmpty {
+                                self.coordinator?.setNavigationController(StartViewController())
+                            }
+                        }
                     }
                 }
             }

--- a/dogether/Presentation/Features/GroupManagement/GroupManagementViewModel.swift
+++ b/dogether/Presentation/Features/GroupManagement/GroupManagementViewModel.swift
@@ -26,7 +26,7 @@ extension GroupManagementViewModel {
         Task {
             do {
                 let response = try await groupUseCase.getMyGroup()
-                self.groups = response.data.joiningChallengeGroups
+                self.groups = response.joiningChallengeGroups
                 DispatchQueue.main.async {
                     completion()  // 데이터 갱신 후 테이블 뷰 리로드
                 }
@@ -38,9 +38,8 @@ extension GroupManagementViewModel {
 }
 
 extension GroupManagementViewModel {
-    func leaveGroup() async throws {
-        // FIXME: UI 수정 후 내용 반영
-        try await NetworkManager.shared.request(GroupsRouter.leaveGroup)
+    func leaveGroup(groupId: Int) async throws {
+        try await NetworkManager.shared.request(GroupsRouter.leaveGroup(groupId: groupId))
     }
 }
 

--- a/dogether/Presentation/Features/GroupManagement/en.lproj/GroupMock.json
+++ b/dogether/Presentation/Features/GroupManagement/en.lproj/GroupMock.json
@@ -1,29 +1,28 @@
 {
-  "code" : "CGS-0003",
-  "message" : "참여중인 챌린지 그룹 정보를 조회하였습니다.",
-  "data" : {
-    "joiningChallengeGroups" : [ {
-      "groupId" : 1,
-      "groupName" : "폰트의 챌린지",
-      "currentMemberCount" : 3,
-      "maximumMemberCount" : 8,
-      "joinCode" : "G3hIj4kLm",
-      "status" : "RUNNING",
-      "startAt" : "25.03.02",
-      "endAt" : "25.03.05",
-      "progressDay" : 5,
-      "progressRate" : 0.3
-    }, {
-      "groupId" : 2,
-      "groupName" : "켈리와 친구들",
-      "currentMemberCount" : 5,
-      "maximumMemberCount" : 10,
-      "joinCode" : "A1Bc4dEf",
-      "status" : "D_DAY",
-      "startAt" : "25.03.02",
-      "endAt" : "25.03.05",
-      "progressDay" : 2,
-      "progressRate" : 0.5
-    } ]
-  }
+  "joiningChallengeGroups": [
+    {
+      "groupId": 1,
+      "groupName": "폰트의 챌린지",
+      "currentMemberCount": 3,
+      "maximumMemberCount": 8,
+      "joinCode": "G3hIj4kLm",
+      "status": "RUNNING",
+      "startAt": "25.03.02",
+      "endAt": "25.03.05",
+      "progressDay": 5,
+      "progressRate": 0.3
+    },
+    {
+      "groupId": 2,
+      "groupName": "켈리와 친구들",
+      "currentMemberCount": 5,
+      "maximumMemberCount": 10,
+      "joinCode": "A1Bc4dEf",
+      "status": "D_DAY",
+      "startAt": "25.03.02",
+      "endAt": "25.03.05",
+      "progressDay": 2,
+      "progressRate": 0.5
+    }
+  ]
 }

--- a/dogether/Presentation/Features/MyPage/MyPageViewController.swift
+++ b/dogether/Presentation/Features/MyPage/MyPageViewController.swift
@@ -9,8 +9,6 @@ import UIKit
 import SnapKit
 
 final class MyPageViewController: BaseViewController {
-    //    private let viewModel = SettingViewModel()
-    
     private let navigationHeader = NavigationHeader(title: "마이페이지")
     
     // FIXME: API 수정 후 내용 반영

--- a/dogether/Presentation/Features/Setting/SettingViewModel.swift
+++ b/dogether/Presentation/Features/Setting/SettingViewModel.swift
@@ -17,9 +17,8 @@ final class SettingViewModel {
 }
 
 extension SettingViewModel {
-    func leaveGroup() async throws {
-        // FIXME: UI 수정 후 내용 반영
-        try await NetworkManager.shared.request(GroupsRouter.leaveGroup)
+    func leaveGroup(groupId: Int) async throws {
+        try await NetworkManager.shared.request(GroupsRouter.leaveGroup(groupId: groupId))
     }
     
     func logout() {

--- a/dogether/Presentation/Features/Stats/StatsViewModel.swift
+++ b/dogether/Presentation/Features/Stats/StatsViewModel.swift
@@ -93,7 +93,7 @@ extension StatsViewModel {
         Task {
             do {
                 let response = try await groupUseCase.getMyGroup()
-                let challengeGroups = response.data.joiningChallengeGroups
+                let challengeGroups = response.joiningChallengeGroups
                 self.myGroups = challengeGroups // 참여중인 그룹 목록 저장
                 
                 // GroupSortOption 배열로 변환


### PR DESCRIPTION
### 📝 Issue Number
- #29 

### 🔧 변경 사항
- 그룹 관리화면 API 연결
- 그룹 탈퇴 API 연결
- 참여중인 챌린지 그룹 정보 전체 조회 API 응답 구조 변경
- 그룹 탈퇴 후 화면전환 로직 수정

