### PR TITLE
fix #50: 바텀시트에서 항목이 선택되지 않는 버그 수정

### DIFF
--- a/dogether/Presentation/Features/CertificationList/CertificationListViewController.swift
+++ b/dogether/Presentation/Features/CertificationList/CertificationListViewController.swift
@@ -89,16 +89,16 @@ extension CertificationListViewController {
         bottomSheetViewController?.didSelectOption = { [weak self] selected in
             guard let self else { return }
             
-            self.viewModel.selectedGroup = selected.value as? CertificationSortOption
+            viewModel.selectedGroup = selected.value as? CertificationSortOption
             
-            self.certificationListContentView?
+            certificationListContentView?
                 .filterView
                 .sortButton
                 .updateSelectedOption(selected)
             
             if let sortOption = selected.value as? CertificationSortOption {
-                self.viewModel.executeSort(option: sortOption)
-                self.certificationListContentView?.makeContentOffset()
+                viewModel.executeSort(option: sortOption)
+                certificationListContentView?.makeContentOffset()
             }
         }
     }

--- a/dogether/Presentation/Features/Main/MainViewController.swift
+++ b/dogether/Presentation/Features/Main/MainViewController.swift
@@ -412,7 +412,7 @@ extension MainViewController: UIScrollViewDelegate {
 extension MainViewController: BottomSheetDelegate {
     private func configureBottomSheetViewController() {
         let bottomSheetItem = viewModel.challengeGroupInfos.map { $0.bottomSheetItem }
-        let selectedItem = viewModel.selectedGroup?.bottomSheetItem
+        let selectedItem = viewModel.currentGroup.bottomSheetItem
         
         if bottomSheetItem.isEmpty { return }
 
@@ -430,9 +430,8 @@ extension MainViewController: BottomSheetDelegate {
                   let selectedGroup = selectedItem.value as? ChallengeGroupInfo,
                   let selectedIndex = viewModel.challengeGroupInfos.firstIndex(of: selectedGroup) else { return }
             
-            viewModel.selectedGroup = selectedItem.value as? ChallengeGroupInfo
-            viewModel.saveLastSelectedGroup()
             viewModel.setChallengeIndex(index: selectedIndex)
+            viewModel.saveLastSelectedGroup()
             viewModel.setDateOffset(offset: 0)
             loadMainView(selectedIndex: selectedIndex)
         }

--- a/dogether/Presentation/Features/Main/MainViewController.swift
+++ b/dogether/Presentation/Features/Main/MainViewController.swift
@@ -412,11 +412,6 @@ extension MainViewController: UIScrollViewDelegate {
 extension MainViewController: BottomSheetDelegate {
     private func configureBottomSheetViewController() {
         let bottomSheetItem = viewModel.challengeGroupInfos.map { $0.bottomSheetItem }
-        
-        if viewModel.selectedGroup == nil {
-            viewModel.selectedGroup = viewModel.currentGroup
-        }
-        
         let selectedItem = viewModel.selectedGroup?.bottomSheetItem
         
         if bottomSheetItem.isEmpty { return }

--- a/dogether/Presentation/Features/Main/MainViewModel.swift
+++ b/dogether/Presentation/Features/Main/MainViewModel.swift
@@ -58,6 +58,7 @@ extension MainViewModel {
         if let groupIndex {
             currentChallengeIndex = selectedIndex ?? groupIndex
             challengeGroupInfos = newChallengeGroupInfos
+            selectedGroup = challengeGroupInfos[currentChallengeIndex]
         } else {
             noGroupAction()
         }

--- a/dogether/Presentation/Features/Main/MainViewModel.swift
+++ b/dogether/Presentation/Features/Main/MainViewModel.swift
@@ -33,7 +33,6 @@ final class MainViewModel {
     private(set) var currentFilter: FilterTypes = .all
     private(set) var todoList: [TodoInfo] = []
     
-    var selectedGroup: ChallengeGroupInfo? = nil
 
     // MARK: - Computed
     var todoListHeight: Int { todoList.isEmpty ? 0 : 64 * todoList.count + 8 * (todoList.count - 1) }
@@ -58,7 +57,6 @@ extension MainViewModel {
         if let groupIndex {
             currentChallengeIndex = selectedIndex ?? groupIndex
             challengeGroupInfos = newChallengeGroupInfos
-            selectedGroup = challengeGroupInfos[currentChallengeIndex]
         } else {
             noGroupAction()
         }
@@ -162,7 +160,7 @@ extension MainViewModel {
 extension MainViewModel {
     func saveLastSelectedGroup() {
         Task {
-            try await groupUseCase.saveLastSelectedGroup(groupId: selectedGroup?.id)
+            try await groupUseCase.saveLastSelectedGroup(groupId: currentGroup.id)
         }
     }
 }


### PR DESCRIPTION
### 📝 Issue Number
- #50 

### 🔧 변경 사항
- MainViewModel.loadMainView() 내부에 selectedGroup = challengeGroupInfos[currentChallengeIndex] 코드 추가
- MainViewController.configureBottomSheetViewController()에서 selectedGroup == nil 체크 및 대입 로직 제거

###  🔍 변경 이유
- 바텀시트를 열었을 때 selectedItem이 nil로 설정되어 아무 항목도 선택되지 않은 상태고 보이는 버그가 있었습니다.
원인은 selectedGroup이 제대로 설정되지 않은 상태에서 configureBottomSheetViewController()가 먼저 호출되는 
타이밍 이슈였습니다. selectedGroup을 명확하게 ViewModel의 loadMainView() 단계에서 설정했습니다.

