### PR TITLE
그룹원 인증정보 페이지 UI를 개선했어요

### DIFF
--- a/dogether/Data/Network/Response/GetMemberTodosResponse.swift
+++ b/dogether/Data/Network/Response/GetMemberTodosResponse.swift
@@ -19,13 +19,23 @@ struct MemberTodo: Decodable {
     let certificationContent: String?
     let certificationMediaUrl: String?
     let isRead: Bool
+    let reviewFeedback: String?
     
-    init(id: Int, content: String, status: String, certificationContent: String? = nil, certificationMediaUrl: String? = nil, isRead: Bool) {
+    init(
+        id: Int,
+        content: String,
+        status: String,
+        certificationContent: String? = nil,
+        certificationMediaUrl: String? = nil,
+        isRead: Bool,
+        reviewFeedback: String? = nil
+    ) {
         self.id = id
         self.content = content
         self.status = status
         self.certificationContent = certificationContent
         self.certificationMediaUrl = certificationMediaUrl
         self.isRead = isRead
+        self.reviewFeedback = reviewFeedback
     }
 }

--- a/dogether/Data/RepositoryTest/ChallengeGroupsRepositoryTest.swift
+++ b/dogether/Data/RepositoryTest/ChallengeGroupsRepositoryTest.swift
@@ -39,8 +39,8 @@ final class ChallengeGroupsRepositoryTest: ChallengeGroupsProtocol {
     func getMemberTodos(groupId: String, memberId: String) async throws -> GetMemberTodosResponse {
         GetMemberTodosResponse(currentTodoHistoryToReadIndex: 3, todos: [
             MemberTodo(id: 1, content: "신규 기능 개발", status: "CERTIFY_PENDING", isRead: true),
-            MemberTodo(id: 2, content: "치킨 먹기", status: "CERTIFY_PENDING", certificationContent: "치킨 냠냠", isRead: true),
-            MemberTodo(id: 1, content: "신규 기능 개발", status: "CERTIFY_PENDING", isRead: true),
+            MemberTodo(id: 2, content: "치킨 먹기", status: "CERTIFY_PENDING", certificationContent: "치킨 냠냠", isRead: true, reviewFeedback: ""),
+            MemberTodo(id: 1, content: "신규 기능 개발", status: "CERTIFY_PENDING", isRead: true, reviewFeedback: "test"),
             MemberTodo(id: 2, content: "치킨 먹기", status: "CERTIFY_PENDING", certificationContent: "치킨 냠냠", isRead: true),
             MemberTodo(id: 1, content: "신규 기능 개발", status: "REVIEW_PENDING", isRead: false),
             MemberTodo(id: 2, content: "치킨 먹기", status: "REVIEW_PENDING", certificationContent: "치킨 냠냠", certificationMediaUrl: "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e.png", isRead: false),

--- a/dogether/Domain/Entity/Enum/TodoStatus.swift
+++ b/dogether/Domain/Entity/Enum/TodoStatus.swift
@@ -39,6 +39,19 @@ enum TodoStatus: String, CaseIterable {
         }
     }
     
+    var text: String {
+        switch self {
+        case .waitCertification:
+            return "미인증"
+        case .waitExamination:
+            return "검사 대기"
+        case .reject:
+            return "노인정"
+        case .approve:
+            return "인정"
+        }
+    }
+    
     var filterType: FilterTypes {
         switch self {
         case .waitCertification:
@@ -49,6 +62,32 @@ enum TodoStatus: String, CaseIterable {
             return .approve
         case .reject:
             return .reject
+        }
+    }
+    
+    var backgroundColor: UIColor {
+        switch self {
+        case .waitCertification:
+            return .grey300
+        case .waitExamination:
+            return .dogetherYellow
+        case .reject:
+            return .dogetherRed
+        case .approve:
+            return .blue300
+        }
+    }
+    
+    var width: CGFloat {
+        switch self {
+        case .waitCertification:
+            return 52
+        case .waitExamination:
+            return 93
+        case .reject:
+            return 78
+        case .approve:
+            return 66
         }
     }
 }

--- a/dogether/Domain/Entity/Model/MemberCertificationInfo.swift
+++ b/dogether/Domain/Entity/Model/MemberCertificationInfo.swift
@@ -13,6 +13,7 @@ struct MemberCertificationInfo {
     let status: TodoStatus
     let certificationContent: String?
     let certificationMediaUrl: String?
+    let feedback: String?
     var thumbnailStatus: ThumbnailStatus
     
     init(
@@ -21,6 +22,7 @@ struct MemberCertificationInfo {
         status: TodoStatus = .waitExamination,
         certificationContent: String? = nil,
         certificationMediaUrl: String? = nil,
+        feedback: String? = nil,
         thumbnailStatus: ThumbnailStatus = .yet
     ) {
         self.id = id
@@ -28,6 +30,7 @@ struct MemberCertificationInfo {
         self.status = status
         self.certificationContent = certificationContent
         self.certificationMediaUrl = certificationMediaUrl
+        self.feedback = feedback
         self.thumbnailStatus = thumbnailStatus
     }
 }

--- a/dogether/Domain/UseCase/ChallengeGroupUseCase.swift
+++ b/dogether/Domain/UseCase/ChallengeGroupUseCase.swift
@@ -34,7 +34,9 @@ final class ChallengeGroupUseCase {
                 status: TodoStatus(rawValue: $0.status) ?? .waitExamination,
                 certificationContent: $0.certificationContent,
                 certificationMediaUrl: $0.certificationMediaUrl,
-                thumbnailStatus: $0.isRead ? .done : .yet)
+                feedback: $0.reviewFeedback,
+                thumbnailStatus: $0.isRead ? .done : .yet
+            )
         }
         return (currentIndex, memberTodos)
     }

--- a/dogether/Presentation/Common/TodoStatusButton.swift
+++ b/dogether/Presentation/Common/TodoStatusButton.swift
@@ -1,0 +1,87 @@
+//
+//  TodoStatusButton.swift
+//  dogether
+//
+//  Created by seungyooooong on 6/11/25.
+//
+
+import UIKit
+
+final class TodoStatusButton: BaseButton {
+    let type: TodoStatus
+    
+    init(type: TodoStatus) {
+        self.type = type
+        
+        super.init(frame: .zero)
+    }
+    required init?(coder: NSCoder) { fatalError() }
+    
+    private var icon = UIImageView()
+    
+    private var label = UILabel()
+    
+    private let stackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 4
+        stackView.isUserInteractionEnabled = false
+        return stackView
+    }()
+    
+    override func configureView() {
+        backgroundColor = type.backgroundColor
+        layer.cornerRadius = 16
+        
+        icon.image = type.image?.withRenderingMode(.alwaysTemplate)
+        icon.tintColor = .grey900
+        
+        label.text = type.text
+        label.textColor = .grey900
+        label.font = Fonts.body2S
+        
+        let views = icon.image == nil ? [label] : [icon, label]
+        views.forEach { stackView.addArrangedSubview($0) }
+    }
+    
+    override func configureAction() { }
+    
+    override func configureHierarchy() {
+        [stackView].forEach { addSubview($0) }
+    }
+    
+    override func configureConstraints() {
+        self.snp.makeConstraints {
+            $0.width.equalTo(type.width)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        icon.snp.makeConstraints {
+            $0.width.height.equalTo(type == .waitExamination ? 18 : type == .reject ? 22 : 24)    // MARK: 임의로 사이즈 조정
+        }
+    }
+}
+
+extension TodoStatusButton {
+    func update(type: TodoStatus) {
+        backgroundColor = type.backgroundColor
+        icon.image = type.image?.withRenderingMode(.alwaysTemplate)
+        label.text = type.text
+        
+        stackView.arrangedSubviews.forEach { stackView.removeArrangedSubview($0) }
+        
+        let views = icon.image == nil ? [label] : [icon, label]
+        views.forEach { stackView.addArrangedSubview($0) }
+        
+        self.snp.updateConstraints {
+            $0.width.equalTo(type.width)
+        }
+        
+        icon.snp.updateConstraints {
+            $0.width.height.equalTo(type == .waitExamination ? 18 : type == .reject ? 22 : 24)
+        }
+    }
+}

--- a/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
+++ b/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
@@ -64,6 +64,8 @@ final class MemberCertificationViewController: BaseViewController {
         return label
     }()
     
+    private let reviewFeedbackLabel = ReviewFeedbackView()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -221,6 +223,8 @@ extension MemberCertificationViewController {
             string: viewModel.todos[viewModel.currentIndex].content,
             attributes: Fonts.getAttributes(for: Fonts.head1B, textAlignment: .center)
         )
+        
+//        reviewFeedbackLabel.updateFeedback(feedback: viewModel.todos[viewModel.currentIndex].feedback)
         
         statusContentStackView.subviews.forEach { statusContentStackView.removeArrangedSubview($0) }
         [statusView, contentLabel].forEach { statusContentStackView.addArrangedSubview($0) }

--- a/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
+++ b/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
@@ -224,10 +224,15 @@ extension MemberCertificationViewController {
             attributes: Fonts.getAttributes(for: Fonts.head1B, textAlignment: .center)
         )
         
-//        reviewFeedbackLabel.updateFeedback(feedback: viewModel.todos[viewModel.currentIndex].feedback)
-        
         statusContentStackView.subviews.forEach { statusContentStackView.removeArrangedSubview($0) }
         [statusView, contentLabel].forEach { statusContentStackView.addArrangedSubview($0) }
+        
+        reviewFeedbackLabel.isHidden = true
+        guard let feedback = viewModel.todos[viewModel.currentIndex].feedback, feedback.count > 0 else { return }
+        reviewFeedbackLabel.isHidden = false
+        reviewFeedbackLabel.updateFeedback(feedback: feedback)
+        statusContentStackView.addArrangedSubview(reviewFeedbackLabel)
+        reviewFeedbackLabel.snp.makeConstraints { $0.horizontalEdges.equalToSuperview() }
     }
     
     @objc private func tappedThumbnailScrollView(_ gesture: UITapGestureRecognizer) {

--- a/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
+++ b/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
@@ -54,7 +54,7 @@ final class MemberCertificationViewController: BaseViewController {
         return stackView
     }()
     
-    private var statusView = FilterButton(type: .wait)
+    private var statusView = TodoStatusButton(type: .waitCertification)
     
     private let contentLabel = {
         let label = UILabel()
@@ -216,8 +216,7 @@ extension MemberCertificationViewController {
             certificationScrollView.setContentOffset(newOffset, animated: false)
         }
         
-        statusView.isHidden = true  // FIXME: 메모리가 계속 쌓이는 문제가 생길 수 있음. 추후 개선 필요
-        statusView = FilterButton(type: viewModel.todos[viewModel.currentIndex].status.filterType)
+        statusView.update(type: viewModel.todos[viewModel.currentIndex].status)
         
         contentLabel.attributedText = NSAttributedString(
             string: viewModel.todos[viewModel.currentIndex].content,


### PR DESCRIPTION
### 📝 Issue Number
- #49 

### 🔧 변경 사항
- 그룹원 인증정보에서 피드백을 조회할 수 있도록 수정했어요
- 미인증 투두의 버튼이 전체로 나오던 이슈를 수정했어요

###  🔍 변경 이유
- 사용자 피드백을 반영했어요

### 🧐 추가 설명
- 추후에 그룹원 인증정보 UI의 개편이 필요해요 (세로 스크롤 추가 및 그룸원 프로필 정보 관련 개편)
- 내 인증 정보 화면과 UI를 통합하는 과정이 추후에 필요할 수 있어요
