### PR TITLE
사진을 재등록하는 경우 이전 사진이 등록되어있는 상태로 넘어가지 않도록 수정했어요

### DIFF
--- a/dogether/Presentation/Features/Certification/CertificationViewController.swift
+++ b/dogether/Presentation/Features/Certification/CertificationViewController.swift
@@ -286,10 +286,16 @@ extension CertificationViewController {
     private func pickerCompletion(image: UIImage) {
         imageView.image = image
         imageView.updateCertificationContent()
+        
+        // FIXME: 추후 S3Manager를 NetworkManager로 합치면서 loading 로직도 제거해요
         Task {
-            // TODO: 로딩 뷰 추가
+            certificationButton.setButtonStatus(status: .disabled)
+            LoadingManager.shared.showLoading()
+            
             todoInfo.certificationMediaUrl = try await S3Manager.shared.uploadImage(image: image)
+            
             certificationButton.setButtonStatus(status: .enabled)
+            LoadingManager.shared.hideLoading()
         }
     }
 }


### PR DESCRIPTION
### 📝 Issue Number
- #69 

### 🔧 변경 사항
- 사진을 올리면 버튼 상태를 disabled로 수정했다가, 등록이 끝나면 abled상태로 재수정하는 로직을 추가했어요

###  🔍 변경 이유
- 사진을 재등록했는데 이전 사진으로 올라가는 이슈를 방지하기 위해 변경했어요

### 🧐 추가 설명
- 임시로 로딩 뷰도 추가했어요
- 테스트 하다가 발견했는데 수정이 직관적이고 간단해보여서 그냥 제가 호다닥 해버렸습니다
