### PR TITLE
투두 생성 시 작성 순서와 다른 배열 순서 전송 이슈를 해결했어요.

### DIFF
--- a/dogether/Data/Network/NetworkEndpoint.swift
+++ b/dogether/Data/Network/NetworkEndpoint.swift
@@ -24,6 +24,7 @@ enum NetworkMethod: String {
 
 enum Path {
     static let api = "/api"
+    static let v1 = "/v1"
     
     static let auth = "/auth"
     static let groups = "/groups"

--- a/dogether/Data/Network/Router/ChallengeGroupsRouter.swift
+++ b/dogether/Data/Network/Router/ChallengeGroupsRouter.swift
@@ -22,7 +22,7 @@ enum ChallengeGroupsRouter: NetworkEndpoint {
         case .certifyTodo(let todoId, _):   // FIXME: 추후 TodosRouter 분리
             return Path.api + Path.todos + "/\(todoId)/certify"
         case .getMyTodos(let groupId, _):
-            return Path.api + Path.challengeGroups + "/\(groupId)/my-todos"
+            return Path.api + Path.v1 + Path.challengeGroups + "/\(groupId)/my-todos"
         case .getMyYesterdayTodos:
             return Path.api + Path.challengeGroups + "/my/yesterday"
         case .getMemberTodos(let groupId, let memberId):

--- a/dogether/Presentation/Features/TodoWrite/TodoWriteViewModel.swift
+++ b/dogether/Presentation/Features/TodoWrite/TodoWriteViewModel.swift
@@ -47,6 +47,6 @@ extension TodoWriteViewModel {
     }
     
     func createTodos() async throws {
-        try await challengeGroupsUseCase.createTodos(groupId: groupId, todos: todos)
+        try await challengeGroupsUseCase.createTodos(groupId: groupId, todos: todos.reversed())
     }
 }


### PR DESCRIPTION
### 📝 Issue Number
- #73 

### 🔧 변경 사항
- 투두 생성시 요청으로 보내는 투두 내용 배열 순서를 투두 작성순으로 변경했어요.

###  🔍 변경 이유
- 투두가 배열 앞쪽에 쌓이도록 insert(at: 0) 방식으로 추가되고 있어, 서버에 작성 순서대로 전달하기 위해 reversed() 처리했습니다.
