### PR TITLE
그룹원 인증 정보 'readTodo' 호출 로직을 수정했어요

### DIFF
--- a/dogether/Domain/UseCase/ChallengeGroupUseCase.swift
+++ b/dogether/Domain/UseCase/ChallengeGroupUseCase.swift
@@ -41,8 +41,9 @@ final class ChallengeGroupUseCase {
         return (currentIndex, memberTodos)
     }
     
-    func readTodo(todoId: Int) async throws {
-        try await repository.readTodo(todoId: String(todoId))
+    func readTodo(todo: MemberCertificationInfo) async throws {
+        if todo.thumbnailStatus == .done { return }
+        try await repository.readTodo(todoId: String(todo.id))
     }
     
     func certifyTodo(todoId: Int, content: String, mediaUrl: String) async throws {

--- a/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
+++ b/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
@@ -209,9 +209,7 @@ extension MemberCertificationViewController {
     private func updateView() {
         guard !viewModel.todos.isEmpty, viewModel.currentIndex < viewModel.todos.count else { return }
         
-        if viewModel.todos[viewModel.currentIndex].thumbnailStatus == .yet {
-            viewModel.readTodo()
-        }
+        viewModel.readTodo()
         
         thumbnailStackView.arrangedSubviews.enumerated().forEach { index, view in
             guard let view = view as? ThumbnailView else { return }

--- a/dogether/Presentation/Features/MemberCertification/MemberCertificationViewModel.swift
+++ b/dogether/Presentation/Features/MemberCertification/MemberCertificationViewModel.swift
@@ -24,8 +24,6 @@ final class MemberCertificationViewModel {
 
 extension MemberCertificationViewModel {
     func setCurrentIndex(index: Int) {
-        todos[currentIndex].thumbnailStatus = .done
-        
         self.currentIndex = index
     }
 }
@@ -39,7 +37,13 @@ extension MemberCertificationViewModel {
     func readTodo() {
         Task { [weak self] in
             guard let self else { return }
-            try await challengeGroupsUseCase.readTodo(todoId: todos[currentIndex].id)
+            do {
+                try await challengeGroupsUseCase.readTodo(todo: todos[currentIndex])
+                todos[currentIndex].thumbnailStatus = .done
+            } catch {
+                // TODO: 예외 처리 추가
+            }
+            
         }
     }
 }


### PR DESCRIPTION
### 📝 Issue Number
- #77 

### 🔧 변경 사항
- ViewController에 있던 thumbnailStatus 판단 로직을 useCase로 이동했어요
- setCurrentIndex 함수에 있던 thumbnailStatus 변경 로직을 readTodo로 이동했어요

###  🔍 변경 이유
- 비즈니스 로직을 viewController에 넣어놨었네요.. useCase로 이동해 응집도를 올렸어요
- setCurrentIndex에서 왜 thumbnailStatus를 변경했을까요.. 결합도도 엉망이었네요...

### 🧐 추가 설명
- 재홍님 이 API도 예외 처리 추가해주세요
