### PR TITLE
바텀시트의 핸들뷰를 제거했어요.

### DIFF
--- a/dogether/Presentation/Common/BottmSheet/BottomSheetViewController.swift
+++ b/dogether/Presentation/Common/BottmSheet/BottomSheetViewController.swift
@@ -41,14 +41,6 @@ final class BottomSheetViewController: BaseViewController {
         return view
     }()
     
-    private let handleView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .grey600
-        view.layer.cornerRadius = 3
-        view.frame.size = CGSize(width: 40, height: 6)
-        return view
-    }()
-    
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 18, weight: .medium)
@@ -142,7 +134,6 @@ final class BottomSheetViewController: BaseViewController {
     
     override func configureHierarchy() {
         view.addSubview(containerView)
-        containerView.addSubview(handleView)
         containerView.addSubview(titleLabel)
         containerView.addSubview(tableView)
         if shouldShowAddGroupButton {
@@ -159,13 +150,6 @@ final class BottomSheetViewController: BaseViewController {
         containerView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
             $0.height.equalTo(containerHeight)
-        }
-        
-        handleView.snp.makeConstraints {
-            $0.top.equalTo(containerView).inset(8)
-            $0.centerX.equalTo(containerView)
-            $0.width.equalTo(40)
-            $0.height.equalTo(6)
         }
         
         titleLabel.snp.makeConstraints {


### PR DESCRIPTION
### 📝 Issue Number
- #36

### 🔧 변경 사항
- 바텀시트의 handleView를 제거했어요.

###  🔍 변경 이유
- 핸드뷰로 인해 UX에 혼동(화면 스크롤)을 줄 수 있어요.

### 🧐 추가 설명
- 가입한 그룹의 최대갯수 제한이 없어지면 스크롤이 필요하기 때문에 바텀시트 방식변경이 필요해요.
