### PR TITLE
누락된 예외처리를 추가했어요.

### DIFF
--- a/dogether/Data/Network/NetworkError.swift
+++ b/dogether/Data/Network/NetworkError.swift
@@ -16,6 +16,9 @@ enum NetworkError: Error {
     case serverError(message: String)
     case decodingFailed
     case noData
+    case sslError(URLError)
+    case connectionFailed(URLError)
+    case unexpectedStatusCode(code: Int)
     case unknown(Error)
     case dogetherError(code: DogetherCodes, message: String)
 }
@@ -39,6 +42,12 @@ extension NetworkError {
             return "응답 데이터를 해석할 수 없습니다."
         case .noData:
             return "데이터가 없습니다."
+        case .sslError(let error):
+            return "보안 연결 실패: \(error.localizedDescription)"
+        case .connectionFailed(let error):
+            return "네트워크 연결이 불안정합니다. \(error.localizedDescription)"
+        case .unexpectedStatusCode(let code):
+            return "예기치 못한 상태 코드가 반환되었습니다. (코드: \(code))"
         case .unknown(let error):
             return "\(error.localizedDescription)"
         case .dogetherError(code: let code, message: let message):

--- a/dogether/Data/Network/NetworkService.swift
+++ b/dogether/Data/Network/NetworkService.swift
@@ -75,14 +75,22 @@ class NetworkService {
                 throw NetworkError.forbidden
             case 404:
                 throw NetworkError.notFound
-            default:
+            case 500...599:
                 throw NetworkError.serverError(message: "서버 오류가 발생했습니다. (코드: \(statusCode))")
+            default:
+                throw NetworkError.unexpectedStatusCode(code: statusCode)
             }
         } catch let error as DecodingError {
             throw NetworkError.decodingFailed
-        }  catch let error as NetworkError {
+        } catch let error as URLError {
+            if error.code == .secureConnectionFailed || error.code == .serverCertificateUntrusted || error.code == .serverCertificateHasBadDate || error.code == .serverCertificateHasUnknownRoot {
+                throw NetworkError.sslError(error)
+            } else {
+                throw NetworkError.connectionFailed(error)
+            }
+        } catch let error as NetworkError {
             throw error
-         } catch {
+        } catch {
             throw NetworkError.unknown(error)
         }
     }

--- a/dogether/Presentation/Common/Error/ErrorHandlingManager.swift
+++ b/dogether/Presentation/Common/Error/ErrorHandlingManager.swift
@@ -180,11 +180,21 @@ extension ErrorHandlingManager {
     
     private static func configForError(error: NetworkError) -> ErrorTemplateConfig {
         switch error {
-        case .serverError, .unknown:
+        case .connectionFailed:
             return ErrorTemplateConfig(
                 image: .headacheDosik,
                 title: "네트워크 연결이 불안정해요.",
                 subtitle: "연결 상태를 확인한 후 다시 시도해주세요.",
+                leftButtonTitle: "다시 시도",
+                rightButtonTitle: nil,
+                leftActionType: .retry,
+                rightActionType: nil
+            )
+        case .serverError, .sslError:
+            return ErrorTemplateConfig(
+                image: .headacheDosik,
+                title: "서버에 문제가 발생했어요.", // FIXME: 문구 수정필요
+                subtitle: "잠시 후 다시 시도해주세요.",
                 leftButtonTitle: "다시 시도",
                 rightButtonTitle: nil,
                 leftActionType: .retry,

--- a/dogether/Presentation/Common/Error/ErrorViewController.swift
+++ b/dogether/Presentation/Common/Error/ErrorViewController.swift
@@ -13,6 +13,7 @@ final class ErrorViewController: BaseViewController {
 
     // MARK: - Config
     private let config: ErrorTemplateConfig
+    private let showCloseButton: Bool
 
     // MARK: - UI Components
     private let errorView: ErrorView
@@ -28,8 +29,9 @@ final class ErrorViewController: BaseViewController {
     var leftButtonAction: (() -> Void)?
     var rightButtonAction: (() -> Void)?
 
-    init(config: ErrorTemplateConfig) {
+    init(config: ErrorTemplateConfig, showCloseButton: Bool = true) {
         self.config = config
+        self.showCloseButton = showCloseButton
         self.errorView = ErrorView(config: config)
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
@@ -54,15 +56,19 @@ final class ErrorViewController: BaseViewController {
             $0.left.right.bottom.equalToSuperview()
         }
         
-        closeButton.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
-            $0.trailing.equalToSuperview().inset(16)
-            $0.size.equalTo(24)
+        if showCloseButton {
+            closeButton.snp.makeConstraints {
+                $0.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+                $0.trailing.equalToSuperview().inset(16)
+                $0.size.equalTo(24)
+            }
         }
     }
     
     override func configureAction() {
-        closeButton.addTarget(self, action: #selector(didTapClose), for: .touchUpInside)
+        if showCloseButton {
+            closeButton.addTarget(self, action: #selector(didTapClose), for: .touchUpInside)
+        }
         
         errorView.leftButtonAction = { [weak self] in
             guard let self else { return }

--- a/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
+++ b/dogether/Presentation/Features/MemberCertification/MemberCertificationViewController.swift
@@ -208,9 +208,7 @@ extension MemberCertificationViewController {
     
     private func updateView() {
         guard !viewModel.todos.isEmpty, viewModel.currentIndex < viewModel.todos.count else { return }
-        
         tryReadTodo()
-        updateUIAfterTodoRead()
     }
     
     private func tryReadTodo() {

--- a/dogether/Presentation/Features/MemberCertification/MemberCertificationViewModel.swift
+++ b/dogether/Presentation/Features/MemberCertification/MemberCertificationViewModel.swift
@@ -34,16 +34,9 @@ extension MemberCertificationViewModel {
         (currentIndex, todos) = try await challengeGroupsUseCase.getMemberTodos(groupId: groupId, memberId: memberInfo.memberId)
     }
     
-    func readTodo() {
-        Task { [weak self] in
-            guard let self else { return }
-            do {
-                try await challengeGroupsUseCase.readTodo(todo: todos[currentIndex])
-                todos[currentIndex].thumbnailStatus = .done
-            } catch {
-                // TODO: 예외 처리 추가
-            }
-            
-        }
+    func readTodo() async throws {
+        if todos[currentIndex].thumbnailStatus == .done { return }
+        try await challengeGroupsUseCase.readTodo(todo: todos[currentIndex])
+        todos[currentIndex].thumbnailStatus = .done
     }
 }

--- a/dogether/Presentation/Features/Splash/SplashViewController.swift
+++ b/dogether/Presentation/Features/Splash/SplashViewController.swift
@@ -86,18 +86,8 @@ final class SplashViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         Task {
-            try await viewModel.launchApp()
-            try await viewModel.checkUpdate()
-            if viewModel.needUpdate {
-                updateView()
-            } else {
-                let destination = try await viewModel.getDestination()
-                await MainActor.run {
-                    coordinator?.setNavigationController(destination)
-                }
-            }
+            await runSplashFlow()
         }
     }
     
@@ -141,9 +131,45 @@ final class SplashViewController: BaseViewController {
 }
 
 extension SplashViewController {
+    private func runSplashFlow() async {
+        do {
+            try await viewModel.launchApp()
+            try await viewModel.checkUpdate()
+            
+            if viewModel.needUpdate {
+                updateView()
+            } else {
+                try await navigateToInitialDestination()
+            }
+        } catch {
+            await MainActor.run {
+                ErrorHandlingManager.presentErrorView(
+                    error: error,
+                    presentingViewController: self,
+                    coordinator: coordinator,
+                    retryHandler: { [weak self] in
+                        guard let self else { return }
+                        Task {
+                            await self.runSplashFlow()
+                        }
+                    },
+                    showCloseButton: false
+                )
+            }
+        }
+    }
+    
+    @MainActor
     func updateView() {
         logoView.isHidden = viewModel.needUpdate
         updateContainer.isHidden = !viewModel.needUpdate
         updateButton.isHidden = !viewModel.needUpdate
+    }
+    
+    private func navigateToInitialDestination() async throws {
+        let destination = try await viewModel.getDestination()
+        await MainActor.run {
+            coordinator?.setNavigationController(destination)
+        }
     }
 }


### PR DESCRIPTION
### 📝 Issue Number
- #74 

### 🔧 변경 사항
- 누락된 스플래시뷰에 에러 처리를 추가했어요.
- ErrorHandlingManager의 handle(error:) 파라미터 타입을 NetworkError → Error로 확장했어요.
- 서버 에러를 네트워크 에러와 분리해 별도 에러로 처리하도록 분기했어요.
- 누락된 사용자 인증정보 화면의 예외처리를 추가했어요.

###  🔍 변경 이유
- 네트워크 에러 외의 다양한 예외 상황에서도 재사용 가능한 에러 처리 흐름이 필요했어요.
- 서버 에러인데도 ‘네트워크 에러’로 표시되는 문제가 있어, 실제 에러 상황에 맞는 안내를 하기 위해 개선했어요.

### 🧐 추가 설명
-  앱 실행 시 SSL 관련 서버에러가 발생했는데 네트워크 에러화면이 떠서, 서버 에러화면을 추가하고 분기했어요.
- 비동기 흐름을 리팩했는데 잘못된점이 없는지 확인부탁드려요.
