### PR TITLE
공백만 입력 시 작성 완료 처리되지 않도록 막아요

### DIFF
--- a/dogether/Presentation/Features/Certification/CertificationSupplyViewController.swift
+++ b/dogether/Presentation/Features/Certification/CertificationSupplyViewController.swift
@@ -191,8 +191,11 @@ extension CertificationSupplyViewController: UITextViewDelegate {
         guard let textView = textView as? DogetherTextView else { return }
         textView.updateTextInfo()
         viewModel.setText(textView.text)
-        
-        certificationButton.setButtonStatus(status: textView.text.isEmpty ? .disabled : .enabled)
+        certificationButton.setButtonStatus(
+            status: textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? .disabled
+            : .enabled
+        )
     }
     
     func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {

--- a/dogether/Presentation/Features/Popup/PopupViewController.swift
+++ b/dogether/Presentation/Features/Popup/PopupViewController.swift
@@ -124,8 +124,12 @@ extension PopupViewController: UITextViewDelegate {
         textView.updateTextInfo()
         viewModel.setStringContent(textView.text)
         
-        if let popupView = popupView as? ReviewFeedbackPopupView, textView.text.count > 0 {
-            popupView.reviewFeedbackButton.setButtonStatus(status: .enabled)
+        if let popupView = popupView as? ReviewFeedbackPopupView {
+            popupView.reviewFeedbackButton.setButtonStatus(
+                status: textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? .disabled
+                : .enabled
+            )
         }
     }
     

--- a/dogether/Presentation/Features/TodoWrite/TodoWriteViewController.swift
+++ b/dogether/Presentation/Features/TodoWrite/TodoWriteViewController.swift
@@ -60,7 +60,7 @@ final class TodoWriteViewController: BaseViewController {
     
     private let addButton = {
         let button = UIButton()
-        button.backgroundColor = .blue300
+        button.backgroundColor = .grey600 // FIXME: 디자이너분들과 상의필요
         button.layer.cornerRadius = 8
         
         let imageView = UIImageView()
@@ -129,7 +129,7 @@ final class TodoWriteViewController: BaseViewController {
     override func configureView() {
         updateView()
         todoTextField.attributedPlaceholder = NSAttributedString(
-            string: "예) 30분 걷기, 책 20페이지 읽기",
+            string: "예) 30분 걷기, 책 20페이지 읽기", // FIXME: 작성투두가 10/10일때 "더 이상 추가할 수 없습니다."로 수정하는거 어떨까요?
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.grey500]
         )
     }
@@ -145,6 +145,7 @@ final class TodoWriteViewController: BaseViewController {
                 guard let self else { return }
                 viewModel.updateTodo(todo: todoTextField.text)
                 updateTextField()
+                updateAddButtonStatus()
             }, for: .editingChanged
         )
         
@@ -157,6 +158,7 @@ final class TodoWriteViewController: BaseViewController {
                     viewModel.updateTodo(todo: "")
                     updateTextField()
                     updateView()
+                    updateAddButtonStatus()
                 }
             }, for: .touchUpInside
         )
@@ -240,16 +242,16 @@ extension TodoWriteViewController {
     private func updateView() {
         updateTextField()
         updateTodoLimitLabel()
-        
         emptyListView.isHidden = !viewModel.todos.isEmpty
         todoTableView.isHidden = viewModel.todos.isEmpty
         todoTableView.reloadData()
         
-        saveButton.setButtonStatus(status: viewModel.todos.isEmpty ? .disabled : .enabled)
+        saveButton.setButtonStatus(status: viewModel.todos.isEmpty ? .disabled : .enabled) // FIXME: 새로 작성한 투두 없을땐 disable되게 수정필요 (기존에 작성된 투두가 있을 경우 항상 enable상태임)
     }
     
     private func updateTextField() {
         todoTextField.text = viewModel.todo
+        todoTextField.isEnabled = viewModel.todos.count < viewModel.maximumTodoCount
         todoLimitTextCount.text = "\(viewModel.todo.count)/\(viewModel.todoMaxLength)"
     }
     
@@ -272,6 +274,12 @@ extension TodoWriteViewController {
         }
 
         todoLimitLabel.attributedText = attributedText
+    }
+    
+    private func updateAddButtonStatus() {
+        let trimmed = todoTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        addButton.isEnabled = !trimmed.isEmpty
+        addButton.backgroundColor = trimmed.isEmpty ? .grey600 : .blue300 // FIXME: 디자이너분들과 상의필요
     }
 }
 
@@ -306,6 +314,7 @@ extension TodoWriteViewController: UITextFieldDelegate {
                viewModel.updateTodo(todo: "")
                updateTextField()
                updateView()
+               updateAddButtonStatus()
            }
         return true
     }
@@ -336,7 +345,7 @@ extension TodoWriteViewController {
                     coordinator: self.coordinator,
                     retryHandler: { [weak self] in
                         guard let self else { return }
-                        trySaveTodo()  // 다시 시도 시, 팝업 없이 저장만 재시도
+                        trySaveTodo()
                     }
                 )
             }

--- a/dogether/Presentation/Features/TodoWrite/TodoWriteViewController.swift
+++ b/dogether/Presentation/Features/TodoWrite/TodoWriteViewController.swift
@@ -60,7 +60,7 @@ final class TodoWriteViewController: BaseViewController {
     
     private let addButton = {
         let button = UIButton()
-        button.backgroundColor = .grey600 // FIXME: 디자이너분들과 상의필요
+        button.backgroundColor = .grey600
         button.layer.cornerRadius = 8
         button.tintColor = .grey400
         let imageView = UIImageView()


### PR DESCRIPTION
### 📝 Issue Number
- #89 

### 🔧 변경 사항
- PR에서 변경된 사항을 작성해주세요
- 인증하기 페이지의 인증내용 작성 시 공백만 입력했을 경우 인증하기 버튼 활성화 막음 
- 투두 작성 페이지에서 투두 작성 시 공백만 입력했을 경우 addButton 활성화 막음
- 투두 검사 페이지의 이유 작성 시 공백만 입력했을 경우 등록하기 버튼 활성화 막음

###  🔍 변경 이유
- 공백(스페이스바)만 입력하는 경우를 방지해요.

### 🧐 추가 설명
- 투두 작성 페이지에서 작성한 투두가 10/10일때 todoTextField의 Placeholder를 "더 이상 추가할 수 없습니다."로 수정하는거 어떨까요? 
- 이미 투두가 작성되어있는 상태에서 투두를 추가하기 위해 투두 작성페이지로 진입했을 때, 투두 저장버튼이 항상 enable상태에요. 아직 추가 투두를 작성하지 않았는데 enable상태인게 어색하다고 느껴집니다. 새로 작성한 투두 없을땐 disable 상태일수 있도록 수정이 필요하다고 생각합니다. + 이때 추가로 투두를 작성하지 않고 투두저장 버튼을 누르면 에러가 발생합니다. 
- 투두 작성 페이지에서 addButton의 기본 상태를 blue300 에서 grey600 으로 변경하고, 텍스트필드에 입력된 내용이 있을때만 blue300으로 변경되도록 수정했어요. 이 부분에 대해서 디자이너분들의 의견이 필요합니다. 디자이너분들께 여쭤보고 공유드리도록 하겠습니다.






