### PR TITLE
작은 아이폰 화면에서 통계 페이지의 하단이 잘려 보이지 않는 문제를 해결했어요.

### DIFF
--- a/dogether/Presentation/Features/Stats/Components/StatsContentView.swift
+++ b/dogether/Presentation/Features/Stats/Components/StatsContentView.swift
@@ -99,6 +99,7 @@ final class StatsContentView: BaseView {
             $0.top.equalTo(dailyAchievementBarView.snp.bottom).offset(16)
             $0.leading.equalToSuperview().inset(16)
             $0.height.equalTo(180)
+            $0.bottom.equalToSuperview().inset(22)
         }
 
         statsSummaryView.snp.makeConstraints {
@@ -107,6 +108,7 @@ final class StatsContentView: BaseView {
             $0.trailing.equalToSuperview().inset(16)
             $0.width.equalTo(myRankView.snp.width)
             $0.height.equalTo(180)
+            $0.bottom.equalToSuperview().inset(22)
         }
     }
     

--- a/dogether/Presentation/Features/Stats/StatsViewController.swift
+++ b/dogether/Presentation/Features/Stats/StatsViewController.swift
@@ -11,6 +11,8 @@ final class StatsViewController: BaseViewController {
     var viewModel = StatsViewModel()
     private let navigationHeader = NavigationHeader(title: "통계")
     private let emptyView = GroupEmptyView()
+    private let scrollView = UIScrollView()
+    private let scrollContentView = UIView()
     private var contentView: StatsContentView?
     private var errorView: ErrorView?
     private var bottomSheetViewController: BottomSheetViewController?
@@ -50,24 +52,69 @@ final class StatsViewController: BaseViewController {
 
 extension StatsViewController {
     private func displayViewForCurrentStatus() {
-        if viewModel.statsViewStatus == .hasData,
-           contentView == nil {
-            let contentView = StatsContentView(viewModel: viewModel)
-            self.contentView = contentView
-            view.addSubview(contentView)
-            contentView.snp.makeConstraints {
-                $0.top.equalTo(navigationHeader.snp.bottom)
-                $0.left.right.bottom.equalToSuperview()
-            }
-            contentView.isHidden = false
-            
-            configureBottomSheetViewController()
+        switch viewModel.statsViewStatus {
+        case .hasData:
+            showStatsContentView()
+        default:
+            showEmptyState()
         }
     }
     
+    private func showStatsContentView() {
+        hideEmptyState()
+        setupContentView()
+        configureBottomSheetViewController()
+    }
+    
+    private func showEmptyState() {
+        emptyView.isHidden = false
+    }
+    
+    private func hideEmptyState() {
+        emptyView.isHidden = true
+    }
+}
+
+extension StatsViewController {
+    private func setupContentView() {
+        let contentView = StatsContentView(viewModel: viewModel)
+        self.contentView = contentView
+        
+        setupScrollViewHierarchy()
+        setupConstraints(for: contentView)
+        
+        contentView.isHidden = false
+        contentView.delegate = self
+    }
+    
+    private func setupScrollViewHierarchy() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(scrollContentView)
+    }
+    
+    private func setupConstraints(for contentView: StatsContentView) {
+        scrollContentView.addSubview(contentView)
+        
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(navigationHeader.snp.bottom)
+            $0.left.right.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        scrollContentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalToSuperview()
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
+
+extension StatsViewController {
     private func configureBottomSheetViewController() {
         let bottomSheetItem = viewModel.groupSortOptions.map { $0.bottomSheetItem }
-        // 선택된 그룹이 있는 경우 해당 항목 찾기
         let selectedItem = viewModel.selectedGroup?.bottomSheetItem
         
         guard !bottomSheetItem.isEmpty else { return }
@@ -93,24 +140,24 @@ extension StatsViewController: StatsViewModelDelegate {
     func didFetchStatsSucceed() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-           contentView?.removeFromSuperview()
-           contentView = nil
-           displayViewForCurrentStatus()
-           contentView?.delegate = self
-           errorView?.removeFromSuperview()
-           errorView = nil
+            scrollView.removeFromSuperview()
+            contentView?.removeFromSuperview()
+            contentView = nil
+            displayViewForCurrentStatus()
+            errorView?.removeFromSuperview()
+            errorView = nil
         }
     }
     
     func didFetchStatsFail(error: NetworkError) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-
+            scrollView.removeFromSuperview()
             contentView?.removeFromSuperview()
             contentView = nil
-            emptyView.removeFromSuperview()
+            emptyView.isHidden = true
             errorView?.removeFromSuperview()
-
+            
             let newErrorView = ErrorHandlingManager.embedErrorView(
                 in: self,
                 under: navigationHeader,


### PR DESCRIPTION
### 📝 Issue Number
- #101 

### 🔧 변경 사항
- StatsViewController에서 contentView를 scrollView로 감싸도록 구조를 변경했어요
- scrollContentView를 추가해서 scrollView가 contentSize를 안정적으로 계산하도록 구현했어요

###  🔍 변경 이유
- 기존에는 작은 화면에서 contentView 하단이 잘려 일부 정보가 보이지 않았어요
- 스크롤을 통해 화면을 내려 확인할 수 있도록 scrollView 구조로 개선했어요

### 🔗 참고 자료
https://github.com/user-attachments/assets/f7cdea0e-4015-4dff-a8db-0d16eaded501

서나 스크린 샷 등을 첨부해주세요

### 🧐 추가 설명
- ScrollView 안에 scrollContentView를 두고 그 안에 contentView를 넣는 구조로 만들었어요
- scrollContentView는 scrollView의 edges와 width를 슈퍼뷰에 맞춰 꽉 채우도록 제약을 걸었어요
- 이렇게 중간에 scrollContentView를 둔 이유는, contentView만 바로 scrollView에 넣으면 Auto Layout 상에서 contentView 높이가 불확실(ambiguous)해져 scrollView가 contentSize를 정확히 계산하지 못하기 때문이에요 (스크롤 안생김..)
- scrollContentView가 contentView를 감싸면서 contentView 높이에 따라 scrollContentView가 늘어나거나 줄어들고, scrollView가 안정적으로 contentSize를 계산할 수 있게 되었어요




