### PR TITLE
SpalshView에서의 로딩 애니메이션이 끊기지 않도록 개선했어요

### DIFF
--- a/dogether/Presentation/Features/Splash/SplashViewController.swift
+++ b/dogether/Presentation/Features/Splash/SplashViewController.swift
@@ -60,6 +60,10 @@ final class SplashViewController: BaseViewController {
 extension SplashViewController {
     private func onAppear() {
         Task {
+            // MARK: SplashView의 경우 API 호출에 순서가 정해져있어 동기 호출 방식 보다는 로딩바를 임시로 하나 더 추가해 제어함
+            LoadingManager.shared.showLoading()
+            defer { LoadingManager.shared.hideLoading() }
+            
             do {
                 try await viewModel.launchApp()
                 


### PR DESCRIPTION
### 📝 Issue Number
- #91 

### 🔧 변경 사항
- SplashViewController의 onAppear에 Loading을 추가했어요

###  🔍 변경 이유
- SplashView의 경우 두 개의 API가 호출되는 데, 첫번째 API의 결과에 따라 두번째 API 호출 여부가 정해지기 때문에 동기 처리를 추가하지 않고, 비동기 처리를 유지한채로 전체적인 Loading을 하나 더 추가했어요

### 🧐 추가 설명
- 이슈에서 언급해주신 4번의 경우 중 2번은 메인화면 API 호출에서의 로딩이에요, 따라서 SplashView의 로딩은 해당 이슈에서 수정하고, #48 에서 메인 화면을 개선하면서 동기 처리를 대입할 예정이에요
