### PR TITLE
유효하지 않은 그룹 코드 입력 시 에러 화면 대신 안내 문구를 표시해요.

### DIFF
--- a/dogether/Domain/Entity/Enum/GroupJoinStatus.swift
+++ b/dogether/Domain/Entity/Enum/GroupJoinStatus.swift
@@ -9,13 +9,13 @@ import UIKit
 
 enum GroupJoinStatus {
     case normal
-    case error
+    case invalidCode
     
     var text: String {
         switch self {
         case .normal:
             return "초대받은 링크에서 초대코드를 확인할 수 있어요"
-        case .error:
+        case .invalidCode:
             return "해당 번호는 유효하지 않아요 !"  // FIXME: 추후에 에러 케이스 세분화 하며 함께 수정 필요 (원래 문구 '유효 -> '존재')
         }
     }
@@ -24,7 +24,7 @@ enum GroupJoinStatus {
         switch self {
         case .normal:
             return .grey200
-        case .error:
+        case .invalidCode:
             return .dogetherRed
         }
     }
@@ -33,7 +33,7 @@ enum GroupJoinStatus {
         switch self {
         case .normal:
             return Fonts.body1R
-        case .error:
+        case .invalidCode:
             return Fonts.body1S
         }
     }
@@ -42,7 +42,7 @@ enum GroupJoinStatus {
         switch self {
         case .normal:
             return .clear
-        case .error:
+        case .invalidCode:
             return .dogetherRed
         }
     }

--- a/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
+++ b/dogether/Presentation/Features/GroupJoin/GroupJoinViewController.swift
@@ -142,15 +142,23 @@ extension GroupJoinViewController {
                     coordinator?.setNavigationController(completeViewController)
                 }
             } catch let error as NetworkError {
-                ErrorHandlingManager.presentErrorView(
-                    error: error,
-                    presentingViewController: self,
-                    coordinator: coordinator,
-                    retryHandler: { [weak self] in
+                if case let .dogetherError(code, _) = error, code == .CGF0005 {
+                    await MainActor.run { [weak self] in
                         guard let self else { return }
-                        tryJoinGroup()
+                        viewModel.handleInvalidCode()
+                        updateSubTitleLabel()
                     }
-                )
+                } else {
+                    ErrorHandlingManager.presentErrorView(
+                        error: error,
+                        presentingViewController: self,
+                        coordinator: coordinator,
+                        retryHandler: { [weak self] in
+                            guard let self else { return }
+                            tryJoinGroup()
+                        }
+                    )
+                }
             }
         }
     }

--- a/dogether/Presentation/Features/GroupJoin/GroupJoinViewModel.swift
+++ b/dogether/Presentation/Features/GroupJoin/GroupJoinViewModel.swift
@@ -37,9 +37,8 @@ extension GroupJoinViewModel {
 }
 
 extension GroupJoinViewModel {
-    func handleCodeError() {
-        setGroupJoinStatus(.error)
-        setCode("")
+    func handleInvalidCode() {
+        setGroupJoinStatus(.invalidCode)
     }
     
     func joinGroup() async throws {


### PR DESCRIPTION
### 📝 Issue Number
- #104

### 🔧 변경 사항
- 그룹 가입 화면에서 잘못된 그룹 코드를 입력했을 때, 기존에는 전체 에러 화면으로 이동했음
- 에러 화면 대신, 화면 내 subTitleLabel에 "해당 번호는 유효하지 않아요!" 문구가 표시되도록 수정

###  🔍 변경 이유
- 잘못된 코드 입력은 네트워크 에러라기보다 사용자 입력 오류에 해당
- 기존처럼 에러 화면으로 이동하면 맥락이 끊겨 UX가 불편함
- 화면 내에서 즉시 피드백을 주는 것이 사용자 경험에 더 적합하다고 판단

### 🧐 추가 설명
- 에러 화면으로 이동하는 흐름은 그대로 유지하되, 
CGF0005(존재하지 않는 그룹) 오류에 한해서만 화면 내 안내 문구로 처리하도록 예외 처리했어요
