### PR TITLE
viewDidUpdate를 updateVIew로 통일시켜 단순화했어요

### DIFF
--- a/dogether/Presentation/Base/BaseButton.swift
+++ b/dogether/Presentation/Base/BaseButton.swift
@@ -31,22 +31,5 @@ class BaseButton: UIButton {
     func configureConstraints() { }
     
     /// 뷰의 가변 요소들을 업데이트하는 역할을 합니다
-    func viewDidUpdate(_ data: any BaseEntity) {
-        updateView(data)
-        updateAction(data)
-        updateHierarchy(data)
-        updateConstraints(data)
-    }
-    
-    /// 뷰의 시각적인 속성을 업데이트하는 역할을 합니다
     func updateView(_ data: any BaseEntity) { }
-    
-    /// 뷰의 동작 및 이벤트 처리를 업데이트하는 역할을 합니다
-    func updateAction(_ data: any BaseEntity) { }
-    
-    /// 뷰 계층을 업데이트하는 역할을 합니다
-    func updateHierarchy(_ data: any BaseEntity) { }
-    
-    /// SnapKit을 이용해 레이아웃을 업데이트하는 역할을 합니다
-    func updateConstraints(_ data: any BaseEntity) { }
 }

--- a/dogether/Presentation/Base/BasePage.swift
+++ b/dogether/Presentation/Base/BasePage.swift
@@ -31,22 +31,5 @@ class BasePage: UIView {
     func configureConstraints() { }
     
     /// 뷰의 가변 요소들을 업데이트하는 역할을 합니다
-    func viewDidUpdate(_ data: any BaseEntity) {
-        updateView(data)
-        updateAction(data)
-        updateHierarchy(data)
-        updateConstraints(data)
-    }
-    
-    /// 뷰의 시각적인 속성을 업데이트하는 역할을 합니다
     func updateView(_ data: any BaseEntity) { }
-    
-    /// 뷰의 동작 및 이벤트 처리를 업데이트하는 역할을 합니다
-    func updateAction(_ data: any BaseEntity) { }
-    
-    /// 뷰 계층을 업데이트하는 역할을 합니다
-    func updateHierarchy(_ data: any BaseEntity) { }
-    
-    /// SnapKit을 이용해 레이아웃을 업데이트하는 역할을 합니다
-    func updateConstraints(_ data: any BaseEntity) { }
 }

--- a/dogether/Presentation/Base/BaseView.swift
+++ b/dogether/Presentation/Base/BaseView.swift
@@ -31,22 +31,5 @@ class BaseView: UIView {
     func configureConstraints() { }
     
     /// 뷰의 가변 요소들을 업데이트하는 역할을 합니다
-    func viewDidUpdate(_ data: any BaseEntity) {
-        updateView(data)
-        updateAction(data)
-        updateHierarchy(data)
-        updateConstraints(data)
-    }
-    
-    /// 뷰의 시각적인 속성을 업데이트하는 역할을 합니다
     func updateView(_ data: any BaseEntity) { }
-    
-    /// 뷰의 동작 및 이벤트 처리를 업데이트하는 역할을 합니다
-    func updateAction(_ data: any BaseEntity) { }
-    
-    /// 뷰 계층을 업데이트하는 역할을 합니다
-    func updateHierarchy(_ data: any BaseEntity) { }
-    
-    /// SnapKit을 이용해 레이아웃을 업데이트하는 역할을 합니다
-    func updateConstraints(_ data: any BaseEntity) { }
 }

--- a/dogether/Presentation/Base/BaseViewController.swift
+++ b/dogether/Presentation/Base/BaseViewController.swift
@@ -70,7 +70,7 @@ class BaseViewController: UIViewController, CoordinatorDelegate {
             .asDriver(onErrorJustReturn: relay.value)
             .drive(onNext: { [weak self] datas in
                 guard let self, let pages else { return }
-                pages.forEach { $0.viewDidUpdate(datas) }
+                pages.forEach { $0.updateView(datas) }
             })
             .disposed(by: disposeBag)
     }

--- a/dogether/Presentation/Features/Main/Components/DosikCommentButton.swift
+++ b/dogether/Presentation/Features/Main/Components/DosikCommentButton.swift
@@ -63,7 +63,7 @@ final class DosikCommentButton: BaseButton {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: (any BaseEntity)?) {
         if let data = data as? GroupEntity {
             let comment = data.status == .dDay ? "그룹이 종료됐어요!" :

--- a/dogether/Presentation/Features/Main/Components/GroupInfoView.swift
+++ b/dogether/Presentation/Features/Main/Components/GroupInfoView.swift
@@ -163,7 +163,7 @@ final class GroupInfoView: BaseView {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: (any BaseEntity)?) {
         if let data = data as? GroupEntity {
             nameLabel.text = data.name

--- a/dogether/Presentation/Features/Main/Components/MainPage.swift
+++ b/dogether/Presentation/Features/Main/Components/MainPage.swift
@@ -117,17 +117,17 @@ final class MainPage: BasePage {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: (any BaseEntity)?) {
         if let datas = data as? BottomSheetViewDatas {
-            bottomSheetView.viewDidUpdate(datas)
+            bottomSheetView.updateView(datas)
         }
         
         if let datas = data as? GroupViewDatas, datas.groups.count > 0 {
-            bottomSheetView.viewDidUpdate(datas)
-            groupInfoView.viewDidUpdate(datas.groups[datas.index])
-            dosikCommentButton.viewDidUpdate(datas.groups[datas.index])
-            sheetHeaderView.viewDidUpdate(datas)
+            bottomSheetView.updateView(datas)
+            groupInfoView.updateView(datas.groups[datas.index])
+            dosikCommentButton.updateView(datas.groups[datas.index])
+            sheetHeaderView.updateView(datas)
         }
         
         if let datas = data as? SheetViewDatas {
@@ -135,9 +135,9 @@ final class MainPage: BasePage {
                 currentIsScrollOnTop = datas.isScrollOnTop
             }
             
-            groupInfoView.viewDidUpdate(datas)
-            rankingButton.viewDidUpdate(datas)
-            sheetHeaderView.viewDidUpdate(datas)
+            groupInfoView.updateView(datas)
+            rankingButton.updateView(datas)
+            sheetHeaderView.updateView(datas)
             
             timerView.isHidden = !(datas.status == .timer)
             todoListView.isHidden = !(datas.status == .certificateTodo || datas.status == .todoList)
@@ -152,17 +152,9 @@ final class MainPage: BasePage {
             }
             
             if datas.status == .certificateTodo || datas.status == .todoList {
-                todoListView.viewDidUpdate(datas)
+                todoListView.updateView(datas)
             }
-        }
-        
-        if let datas = data as? TimerViewDatas {
-            timerView.viewDidUpdate(datas)
-        }
-    }
-    
-    override func updateConstraints(_ data: any BaseEntity) {
-        if let datas = data as? SheetViewDatas {
+            
             if currentYOffset == datas.yOffset && currentSheetStatus == datas.sheetStatus { return }
             currentYOffset = datas.yOffset
             currentSheetStatus = datas.sheetStatus
@@ -170,6 +162,10 @@ final class MainPage: BasePage {
             dogetherSheet.snp.updateConstraints {
                 $0.top.equalToSuperview().offset(datas.yOffset)
             }
+        }
+        
+        if let datas = data as? TimerViewDatas {
+            timerView.updateView(datas)
         }
     }
 }

--- a/dogether/Presentation/Features/Main/Components/SheetHeaderView.swift
+++ b/dogether/Presentation/Features/Main/Components/SheetHeaderView.swift
@@ -71,7 +71,7 @@ final class SheetHeaderView: BaseView {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: (any BaseEntity)?) {
         if let datas = data as? GroupViewDatas {
             if currentGroupDuration == datas.groups[datas.index].duration { return }

--- a/dogether/Presentation/Features/Main/Components/TimerView.swift
+++ b/dogether/Presentation/Features/Main/Components/TimerView.swift
@@ -111,7 +111,7 @@ final class TimerView: BaseView {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: (any BaseEntity)?) {
         if let datas = data as? TimerViewDatas {
             timerLabel.text = datas.time

--- a/dogether/Presentation/Features/Main/Components/TodoListView.swift
+++ b/dogether/Presentation/Features/Main/Components/TodoListView.swift
@@ -114,7 +114,7 @@ final class TodoListView: BaseView {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: any BaseEntity) {
         if let datas = data as? SheetViewDatas {
             todoScrollView.isScrollEnabled = datas.sheetStatus == .expand
@@ -123,7 +123,7 @@ final class TodoListView: BaseView {
             currentFilter = datas.filter
             currentTodoList = datas.todoList
             
-            [allButton, waitButton, rejectButton, approveButton].forEach { $0.viewDidUpdate(datas.filter) }
+            [allButton, waitButton, rejectButton, approveButton].forEach { $0.updateView(datas.filter) }
             
             let isToday = datas.dateOffset == 0
             
@@ -143,7 +143,7 @@ final class TodoListView: BaseView {
                 .forEach { todoListStackView.addArrangedSubview($0) }
             
             if datas.todoList.count < 10 && isToday {
-                addTodoButton.viewDidUpdate(datas)
+                addTodoButton.updateView(datas)
                 todoListStackView.addArrangedSubview(addTodoButton)
             }
             

--- a/dogether/Presentation/Features/Ranking/Components/RankingPage.swift
+++ b/dogether/Presentation/Features/Ranking/Components/RankingPage.swift
@@ -93,7 +93,7 @@ final class RankingPage: BasePage {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: (any BaseEntity)?) {
         if let datas = data as? RankingViewDatas {
             if currentRankings != datas.rankings {

--- a/dogether/Presentation/Features/Start/Components/StartPage.swift
+++ b/dogether/Presentation/Features/Start/Components/StartPage.swift
@@ -74,7 +74,7 @@ final class StartPage: BasePage {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: (any BaseEntity)?) {
         guard let datas = data as? StartViewDatas else { return }
         
@@ -83,10 +83,6 @@ final class StartPage: BasePage {
         navigationHeader.isHidden = datas.isFirstGroup
         
         titleLabel.isHidden = !datas.isFirstGroup
-    }
-    
-    override func updateConstraints(_ data: (any BaseEntity)?) {
-        guard let datas = data as? StartViewDatas else { return }
         
         buttonStackView.snp.remakeConstraints {
             $0.top.equalTo(datas.isFirstGroup ? titleLabel.snp.bottom : navigationHeader.snp.bottom)

--- a/dogether/Presentation/Features/TodoWrite/Components/TodoWritePage.swift
+++ b/dogether/Presentation/Features/TodoWrite/Components/TodoWritePage.swift
@@ -212,7 +212,7 @@ final class TodoWritePage: BasePage {
         }
     }
     
-    // MARK: - viewDidUpdate
+    // MARK: - updateView
     override func updateView(_ data: (any BaseEntity)?) {
         if let datas = data as? TodoWriteViewDatas {
             if currentTodo != datas.todo {


### PR DESCRIPTION
### 📝 Issue Number
- #110 

### 🔧 변경 사항
- viewDidUpdate를 updateView로 통일시켜 단순화했어요

###  🔍 변경 이유
- page처럼 전체 view들을 조정하기 보다는 view별로 데이터에 맞게 update를 하는 구조이기 때문에 단순화 시켜 updateView에서 모든 처리를 담당하도록 단순화했어요

### 🧐 추가 설명
- 작업 자체는 작았지만 아마 작업하고 계셨던 다른 화면들에서 충돌이 날 수밖에 없을 것 같아요, 해당 PR이 머지되고 나면 리베이스 및 충돌 병합 작업이 꼼꼼하게 필요할 것 같습니다
