### PR TITLE
인증 정보 화면으로 넘기는 투두 리스트에 필터링을 추가했어요

### DIFF
--- a/dogether/Presentation/Features/Main/MainViewController.swift
+++ b/dogether/Presentation/Features/Main/MainViewController.swift
@@ -245,7 +245,9 @@ extension MainViewController: MainDelegate {
         let certificationViewController = CertificationViewController()
         let certificationViewDatas = CertificationViewDatas(
             title: "내 인증 정보",
-            todos: viewModel.sheetViewDatas.value.todoList,
+            todos: viewModel.sheetViewDatas.value.todoList.filter {
+                viewModel.sheetViewDatas.value.filter == .all || viewModel.sheetViewDatas.value.filter == FilterTypes(status: $0.status.rawValue)
+            },
             index: index
         )
         coordinator?.pushViewController(certificationViewController, datas: certificationViewDatas)


### PR DESCRIPTION
### 📝 Issue Number
- #133

### 🔧 변경 사항
- 인증 정보 화면으로 넘기는 투두 리스트에 필터링을 추가했어요

### 🧐 추가 설명
- 기존에는 인덱싱을 수정하려고 계획했으나, 인증 목록 화면에서의 통일성과 사용자 경험을 생각했을 때 인증 정보 화면으로 넘기는 투두 리스트에 필터링을 추가하는 방향으로 개선했어요
