### PR TITLE
통계 페이지 UI 분기 로직을 수정했어요.

### DIFF
--- a/dogether/Presentation/Features/Stats/Components/StatsPage.swift
+++ b/dogether/Presentation/Features/Stats/Components/StatsPage.swift
@@ -132,13 +132,13 @@ final class StatsPage: BasePage {
             bottomSheetView.updateView(datas)
         }
         
-        if let datas = data as? GroupViewDatas, datas.groups.count > 0 {
+        if let datas = data as? GroupViewDatas {
             if datas.groups.isEmpty {
-                emptyView.isHidden = true
-                scrollView.isHidden = false
-            } else {
                 emptyView.isHidden = false
                 scrollView.isHidden = true
+            } else {
+                emptyView.isHidden = true
+                scrollView.isHidden = false
                 
                 bottomSheetView.updateView(datas)
                 groupInfoView.updateView(datas.groups[datas.index])


### PR DESCRIPTION
### 📝 Issue Number
- #145 

### 🔧 변경 사항
- StatsPage.updateView() 내부의 GroupViewDatas 분기 처리 로직 수정
- datas.groups.count > 0 / datas.groups.isEmpty 중복 및 모순 조건 제거
- 그룹 존재 여부에 따라 UI 분기 수정

###  🔍 변경 이유
- 조건이 잘못됨
groups.count > 0 조건 안에서
groups.isEmpty를 다시 검사하는 구조
- UI 표시 분기 또한 반대로 구현되어 있어
그룹이 있어도 EmptyView가 노출되는 버그가 발생

### 🧐 추가 설명
- 통계페이지 작업 머지할때 놓친부분 재작업했습니다!
